### PR TITLE
Fixed error that pops up when no search results are found

### DIFF
--- a/frontend/src/components/WhatsUpModal/WhatsUpModal.tsx
+++ b/frontend/src/components/WhatsUpModal/WhatsUpModal.tsx
@@ -73,7 +73,8 @@ const WhatsUpModal: React.FC<WhatsUpProps> = ({ target, setTarget, location, set
   const queryWhatsUp = async () => {
     let response = await getWhatsUp(location, radius, parseInt(cat))
     setList([] as n2yo_above[]) // Flush this to avoid issues with caching when switching categories
-    setList(response.above)
+    if (response !== null)
+      setList(response.above)
   }
 
   const handleSliderChange = (event: Event, newValue: number | number[]) => {


### PR DESCRIPTION
This was done by making it so 'response.above' is not set as the list if the response is null